### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "stylestudio"
+description = "ComfyUI nodes for StyleStudio model."
+version = "1.0.0"
+license = {file = "LICENSE"}
+dependencies = ["diffusers==0.25.1", "torch==2.1.0", "torchaudio==2.1.0", "torchvision==0.16.0", "transformers==4.45.2", "numpy==1.26.4", "xformers==0.0.22.post7", "tokenizers==0.19.1", "accelerate", "safetensors", "einops", "spaces==0.19.4", "omegaconf", "peft", "huggingface-hub==0.24.6", "opencv-python", "insightface", "gradio==4.42.0", "controlnet_aux", "gdown", "onnx==1.16.2", "onnxruntime-gpu==1.19.0"]
+
+[project.urls]
+Repository = "https://github.com/Yuan-ManX/ComfyUI-StyleStudio"
+#  Used by Comfy Registry https://comfyregistry.org
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-StyleStudio"
+Icon = ""


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!